### PR TITLE
ci: add Release Please workflow and config

### DIFF
--- a/.github/release-config.json
+++ b/.github/release-config.json
@@ -1,0 +1,12 @@
+{
+  "bump-patch-for-minor-pre-major": true,
+  "bump-minor-pre-major": true,
+  "include-component-in-tag": false,
+  "signoff": "Agntcy Build Bot <build@agntcy.io>",
+  "packages": {
+    ".": {
+      "package-name": "slim-a2a-go",
+      "release-type": "go"
+    }
+  }
+}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,0 +1,21 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release Please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    name: Release Please
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          config-file: .github/release-config.json


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release-please.yaml` to automate release PR creation on pushes to `main`
- Adds `.github/release-config.json` adapted from the main slim repo, simplified for this single-module Go repository

## Stacked on

Stacks on top of #1.