### PR TITLE
fix(a2aclient): rename SLIMProtocol identifier to "slimrpc"

### DIFF
--- a/a2aclient/slim.go
+++ b/a2aclient/slim.go
@@ -16,8 +16,8 @@ import (
 	ourpb "github.com/agntcy/slim-a2a-go/a2apb"
 )
 
-// SLIMProtocol is the transport protocol identifier for SLIM.
-const SLIMProtocol a2a.TransportProtocol = "slim"
+// SLIMProtocol is the transport protocol identifier for SLIM RPC.
+const SLIMProtocol a2a.TransportProtocol = "slimrpc"
 
 // Transport implements a2aclient.Transport over SLIM RPC.
 type Transport struct {


### PR DESCRIPTION
## Summary

- Renames the `SLIMProtocol` constant value from `"slim"` to `"slimrpc"`
- The constant name is unchanged; only the string value changes
- Aligns with a2a-go's naming convention (`"GRPC"`, `"JSONRPC"`) by being specific about the transport variant